### PR TITLE
supported the order not fulfilled scenario in the pizza workflow 

### DIFF
--- a/exercises/querying-workflows/README.md
+++ b/exercises/querying-workflows/README.md
@@ -61,7 +61,7 @@ At this point, you can run your Workflow. Because it is the same Workflow from t
    1. If you're in the GitPod environment you can instead run `ex3`
    2. Otherwise, use:
    ```bash
-   cd exercises/querying-workflows/practice/src
+   cd exercises/querying-workflows/practice
    ```
    3. _Be sure to do this for **every** terminal_
 2. Compile the code using `mvn clean compile`

--- a/exercises/querying-workflows/practice/src/main/java/queryingworkflows/orderpizza/PizzaWorkflowImpl.java
+++ b/exercises/querying-workflows/practice/src/main/java/queryingworkflows/orderpizza/PizzaWorkflowImpl.java
@@ -33,7 +33,9 @@ public class PizzaWorkflowImpl implements PizzaWorkflow {
   @Override
   public OrderConfirmation orderPizza(PizzaOrder order) {
 
-    // TODO: PART A: Assign the value `Started` to `status`
+    // TODO: PART A: Assign the value `Started` to `status`. (It is declared above).
+
+
     String orderNumber = order.getOrderNumber();
     Customer customer = order.getCustomer();
     List<Pizza> items = order.getItems();

--- a/exercises/sending-signals-client/practice/src/main/java/sendingsignalsclient/Starter.java
+++ b/exercises/sending-signals-client/practice/src/main/java/sendingsignalsclient/Starter.java
@@ -14,6 +14,7 @@ import sendingsignalsclient.orderpizza.PizzaWorkflow;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class Starter {
   public static void main(String[] args) throws Exception {
@@ -34,7 +35,7 @@ public class Starter {
 
     PizzaWorkflow pizzaWorkflow = client.newWorkflowStub(PizzaWorkflow.class, pizzaWorkflowOptions);
 
-    OrderConfirmation orderConfirmation = pizzaWorkflow.orderPizza(order);
+    Optional<OrderConfirmation> orderConfirmation = pizzaWorkflow.orderPizza(order);
     //CompletableFuture<OrderConfirmation> orderConfirmation = WorkflowClient.execute(pizzaWorkflow::orderPizza, order);
 
 

--- a/exercises/sending-signals-client/practice/src/main/java/sendingsignalsclient/Starter.java
+++ b/exercises/sending-signals-client/practice/src/main/java/sendingsignalsclient/Starter.java
@@ -36,7 +36,8 @@ public class Starter {
     PizzaWorkflow pizzaWorkflow = client.newWorkflowStub(PizzaWorkflow.class, pizzaWorkflowOptions);
 
     Optional<OrderConfirmation> orderConfirmation = pizzaWorkflow.orderPizza(order);
-    //CompletableFuture<OrderConfirmation> orderConfirmation = WorkflowClient.execute(pizzaWorkflow::orderPizza, order);
+    //CompletableFuture<Optional<OrderConfirmation>> orderConfirmationFuture = WorkflowClient.execute(pizzaWorkflow::orderPizza, order);
+    //Optional<OrderConfirmation> orderConfirmation = orderConfirmationFuture.get();
 
 
     System.out.printf("Workflow result: %s\n", orderConfirmation);

--- a/exercises/sending-signals-client/practice/src/main/java/sendingsignalsclient/orderpizza/PizzaWorkflow.java
+++ b/exercises/sending-signals-client/practice/src/main/java/sendingsignalsclient/orderpizza/PizzaWorkflow.java
@@ -5,12 +5,13 @@ import io.temporal.workflow.WorkflowMethod;
 import io.temporal.workflow.SignalMethod;
 import sendingsignalsclient.model.PizzaOrder;
 import sendingsignalsclient.model.OrderConfirmation;
+import java.util.Optional;
 
 @WorkflowInterface
 public interface PizzaWorkflow {
 
   @WorkflowMethod
-  OrderConfirmation orderPizza(PizzaOrder order);
+  Optional<OrderConfirmation> orderPizza(PizzaOrder order);
 
   @SignalMethod
   void fulfillOrderSignal(boolean bool);

--- a/exercises/sending-signals-client/practice/src/main/java/sendingsignalsclient/orderpizza/PizzaWorkflowImpl.java
+++ b/exercises/sending-signals-client/practice/src/main/java/sendingsignalsclient/orderpizza/PizzaWorkflowImpl.java
@@ -64,7 +64,7 @@ public class PizzaWorkflowImpl implements PizzaWorkflow {
 
     logger.info("distance is {}", distance.getKilometers());
 
-    Workflow.await(Duration.ofSeconds(3),() -> this.signalProcessed);
+    Workflow.await(Duration.ofSeconds(10),() -> this.signalProcessed);
 
     OrderConfirmation confirmation;
 

--- a/exercises/sending-signals-client/practice/src/main/java/sendingsignalsclient/orderpizza/PizzaWorkflowImpl.java
+++ b/exercises/sending-signals-client/practice/src/main/java/sendingsignalsclient/orderpizza/PizzaWorkflowImpl.java
@@ -16,6 +16,7 @@ import sendingsignalsclient.exceptions.OutOfServiceAreaException;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 
@@ -24,19 +25,21 @@ public class PizzaWorkflowImpl implements PizzaWorkflow {
   public static final Logger logger = Workflow.getLogger(PizzaWorkflowImpl.class);
 
   private boolean fulfilled;
+  private boolean signalProcessed;
 
   ActivityOptions options = ActivityOptions.newBuilder().setStartToCloseTimeout(Duration.ofSeconds(5)).build();
 
   private final PizzaActivities activities = Workflow.newActivityStub(PizzaActivities.class, options);
 
   @Override
-  public OrderConfirmation orderPizza(PizzaOrder order) {
+  public Optional<OrderConfirmation> orderPizza(PizzaOrder order) {
 
     String orderNumber = order.getOrderNumber();
     Customer customer = order.getCustomer();
     List<Pizza> items = order.getItems();
     boolean isDelivery = order.isDelivery();
     Address address = order.getAddress();
+    signalProcessed = false;
 
     logger.info("orderPizza Workflow Invoked");
 
@@ -61,7 +64,7 @@ public class PizzaWorkflowImpl implements PizzaWorkflow {
 
     logger.info("distance is {}", distance.getKilometers());
 
-    Workflow.await(() -> this.fulfilled);
+    Workflow.await(Duration.ofSeconds(3),() -> this.signalProcessed);
 
     OrderConfirmation confirmation;
 
@@ -71,21 +74,22 @@ public class PizzaWorkflowImpl implements PizzaWorkflow {
       try {
         confirmation = activities.sendBill(bill);
         logger.info("Bill sent to customer {}", customer.getCustomerID());
+        return Optional.of(confirmation);
       } catch (InvalidChargeAmountException e) {
         logger.error("Unable to bill customer");
         throw Workflow.wrap(e);
       }
     } else {
-      confirmation = null;
       logger.info("Order was not fulfilled. Not billing the customer.");
     }
 
-    return confirmation;
+    return Optional.empty();
 
   }
 
   @Override
   public void fulfillOrderSignal(boolean bool) {
     this.fulfilled = bool;
+    this.signalProcessed = true;
   }
 }

--- a/exercises/sending-signals-client/solution/src/main/java/sendingsignalsclient/Starter.java
+++ b/exercises/sending-signals-client/solution/src/main/java/sendingsignalsclient/Starter.java
@@ -36,7 +36,8 @@ public class Starter {
     PizzaWorkflow pizzaWorkflow = client.newWorkflowStub(PizzaWorkflow.class, pizzaWorkflowOptions);
 
     Optional<OrderConfirmation> orderConfirmation = pizzaWorkflow.orderPizza(order);
-    //CompletableFuture<OrderConfirmation> orderConfirmation = WorkflowClient.execute(pizzaWorkflow::orderPizza, order);
+    // CompletableFuture<Optional<OrderConfirmation>> orderConfirmationFuture = WorkflowClient.execute(pizzaWorkflow::orderPizza, order);
+    // Optional<OrderConfirmation> orderConfirmation = orderConfirmationFuture.get();
 
 
     System.out.printf("Workflow result: %s\n", orderConfirmation);

--- a/exercises/sending-signals-client/solution/src/main/java/sendingsignalsclient/Starter.java
+++ b/exercises/sending-signals-client/solution/src/main/java/sendingsignalsclient/Starter.java
@@ -14,6 +14,7 @@ import sendingsignalsclient.orderpizza.PizzaWorkflow;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class Starter {
   public static void main(String[] args) throws Exception {
@@ -34,7 +35,7 @@ public class Starter {
 
     PizzaWorkflow pizzaWorkflow = client.newWorkflowStub(PizzaWorkflow.class, pizzaWorkflowOptions);
 
-    OrderConfirmation orderConfirmation = pizzaWorkflow.orderPizza(order);
+    Optional<OrderConfirmation> orderConfirmation = pizzaWorkflow.orderPizza(order);
     //CompletableFuture<OrderConfirmation> orderConfirmation = WorkflowClient.execute(pizzaWorkflow::orderPizza, order);
 
 

--- a/exercises/sending-signals-client/solution/src/main/java/sendingsignalsclient/orderpizza/PizzaWorkflow.java
+++ b/exercises/sending-signals-client/solution/src/main/java/sendingsignalsclient/orderpizza/PizzaWorkflow.java
@@ -5,12 +5,13 @@ import io.temporal.workflow.WorkflowMethod;
 import io.temporal.workflow.SignalMethod;
 import sendingsignalsclient.model.PizzaOrder;
 import sendingsignalsclient.model.OrderConfirmation;
+import java.util.Optional;
 
 @WorkflowInterface
 public interface PizzaWorkflow {
 
   @WorkflowMethod
-  OrderConfirmation orderPizza(PizzaOrder order);
+  Optional<OrderConfirmation> orderPizza(PizzaOrder order);
 
   @SignalMethod
   void fulfillOrderSignal(boolean bool);

--- a/exercises/sending-signals-client/solution/src/main/java/sendingsignalsclient/orderpizza/PizzaWorkflowImpl.java
+++ b/exercises/sending-signals-client/solution/src/main/java/sendingsignalsclient/orderpizza/PizzaWorkflowImpl.java
@@ -64,7 +64,7 @@ public class PizzaWorkflowImpl implements PizzaWorkflow {
 
     logger.info("distance is {}", distance.getKilometers());
 
-    Workflow.await(Duration.ofSeconds(3),() -> this.signalProcessed);
+    Workflow.await(Duration.ofSeconds(10),() -> this.signalProcessed);
 
     OrderConfirmation confirmation;
 

--- a/exercises/sending-signals-client/solution/src/main/java/sendingsignalsclient/orderpizza/PizzaWorkflowImpl.java
+++ b/exercises/sending-signals-client/solution/src/main/java/sendingsignalsclient/orderpizza/PizzaWorkflowImpl.java
@@ -16,6 +16,7 @@ import sendingsignalsclient.exceptions.OutOfServiceAreaException;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 
@@ -24,19 +25,21 @@ public class PizzaWorkflowImpl implements PizzaWorkflow {
   public static final Logger logger = Workflow.getLogger(PizzaWorkflowImpl.class);
 
   private boolean fulfilled;
+  private boolean signalProcessed;
 
   ActivityOptions options = ActivityOptions.newBuilder().setStartToCloseTimeout(Duration.ofSeconds(5)).build();
 
   private final PizzaActivities activities = Workflow.newActivityStub(PizzaActivities.class, options);
 
   @Override
-  public OrderConfirmation orderPizza(PizzaOrder order) {
+  public Optional<OrderConfirmation> orderPizza(PizzaOrder order) {
 
     String orderNumber = order.getOrderNumber();
     Customer customer = order.getCustomer();
     List<Pizza> items = order.getItems();
     boolean isDelivery = order.isDelivery();
     Address address = order.getAddress();
+    signalProcessed = false;
 
     logger.info("orderPizza Workflow Invoked");
 
@@ -61,7 +64,7 @@ public class PizzaWorkflowImpl implements PizzaWorkflow {
 
     logger.info("distance is {}", distance.getKilometers());
 
-    Workflow.await(() -> this.fulfilled);
+    Workflow.await(Duration.ofSeconds(3),() -> this.signalProcessed);
 
     OrderConfirmation confirmation;
 
@@ -71,21 +74,22 @@ public class PizzaWorkflowImpl implements PizzaWorkflow {
       try {
         confirmation = activities.sendBill(bill);
         logger.info("Bill sent to customer {}", customer.getCustomerID());
+        return Optional.of(confirmation);
       } catch (InvalidChargeAmountException e) {
         logger.error("Unable to bill customer");
         throw Workflow.wrap(e);
       }
     } else {
-      confirmation = null;
       logger.info("Order was not fulfilled. Not billing the customer.");
     }
 
-    return confirmation;
+    return Optional.empty();
 
   }
 
   @Override
   public void fulfillOrderSignal(boolean bool) {
     this.fulfilled = bool;
+    signalProcessed = true;
   }
 }

--- a/exercises/sending-signals-external/README.md
+++ b/exercises/sending-signals-external/README.md
@@ -36,19 +36,25 @@ In this part of the exercise, you will define your Signal.
 1. Save the file
 1. Open the `PizzaWorkflowImpl.java` file in the `practice/src/main/java/sendingsignalsexternal/orderpizza` subdirectory
 1. Implement the `fulfillOrderSignal` method
-   1. This method should set the instance variable `fulfilled` the the value
-      of the boolean that was passed in as a parameter
+   1. This method should set the instance variable `fulfilled` to the value
+      of the boolean that was passed in as a parameter, and it
+      should set the value of the instance variable `signalProcessed` to true.
 
 ## Part B: Handling the Signal
 
 You will now handle the Signal you defined in part A, and let the Workflow know what to do when it encounters the `fulfillOrderSignal`.
 
 1. Open the `PizzaWorkflowImpl.java` file in the `practice/src/main/java/sendingsignalsexternal/orderpizza` subdirectory.
-   1. In the `orderPizza` method, locate the `Workflow.await(() -> this.fulfilled);` call in the `workflow` method. This will block the Workflow until a Signal is received.
-   1. Locate the code that crafts the `Bill` object and the `try/catch` block that invokes the `sendBill()` method:
-      1. Wrap this call in an if statement that checks to see if the value of the instance variable `fulfilled` is true. If so, execute the activity
-      1. Add a logging statement within the `try/catch` block stating if the Workflow Execution was complete or not and provide the result
-1. Save the file
+
+In the `orderPizza` method, locate the `Workflow.await(Duration.ofSeconds(3),() -> this.signalProcessed);` call in the Workflow Method. This will block the Workflow until a Signal is received or 3 seconds have passed.
+
+Locate the code that crafts the `Bill` object and the `try/catch` block that invokes the `sendBill()` method
+
+2. Wrap this block in an if statement that checks to see if the value of the instance variable `fulfilled` is true.
+
+If so, this will execute the activity to bill the customer.
+
+3. Save the file
 
 ## Part C: Create a Stub on the Pizza Workflow
 
@@ -68,7 +74,7 @@ In this part of the exercise, you will create a stub on the Workflow that you wi
 
 Now that you have a stub on the Workflow you wish to Signal (`pizzaWorkflow`), we will now send `pizzaWorkflow` a Signal.
 
-After you have created a handle, you can see there is some logic to make and deliver the pizzas. Once that is done successfully, the Signal should be sent.
+After you have created the stub, you can see there is some logic to make and deliver the pizzas. Once that is done successfully, the Signal should be sent.
 
 1. After the successful invocations of the activities, use the `workflow` object to call the `fulfillOrderSignal()` method, sending the value of `true`
 1. Within the `catch` block, use the `workflow` object to call the `fulfillOrderSignal()` method but instead send the value of `false` indicating the Workflow was not successful

--- a/exercises/sending-signals-external/practice/src/main/java/sendingsignalsexternal/Starter.java
+++ b/exercises/sending-signals-external/practice/src/main/java/sendingsignalsexternal/Starter.java
@@ -15,6 +15,7 @@ import sendingsignalsexternal.orderpizza.PizzaWorkflow;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class Starter {
   public static void main(String[] args) throws Exception {
@@ -46,7 +47,7 @@ public class Starter {
 
     FulfillOrderWorkflow orderWorkflow = client.newWorkflowStub(FulfillOrderWorkflow.class, fulfillWorkflowOptions);
 
-    CompletableFuture<OrderConfirmation> orderConfirmation = WorkflowClient.execute(pizzaWorkflow::orderPizza, order);
+    CompletableFuture<Optional<OrderConfirmation>> orderConfirmation = WorkflowClient.execute(pizzaWorkflow::orderPizza, order);
 
     CompletableFuture<String> fulfillOrderResult = WorkflowClient.execute(orderWorkflow::fulfillOrder, order,
         pizzaWorkflowID);

--- a/exercises/sending-signals-external/practice/src/main/java/sendingsignalsexternal/orderpizza/PizzaWorkflow.java
+++ b/exercises/sending-signals-external/practice/src/main/java/sendingsignalsexternal/orderpizza/PizzaWorkflow.java
@@ -5,12 +5,13 @@ import io.temporal.workflow.WorkflowMethod;
 import io.temporal.workflow.SignalMethod;
 import sendingsignalsexternal.model.PizzaOrder;
 import sendingsignalsexternal.model.OrderConfirmation;
+import java.util.Optional;
 
 @WorkflowInterface
 public interface PizzaWorkflow {
 
   @WorkflowMethod
-  OrderConfirmation orderPizza(PizzaOrder order);
+  Optional<OrderConfirmation> orderPizza(PizzaOrder order);
 
   // TODO: PART A: Define the Signal method and annotate it appropriately here.
 

--- a/exercises/sending-signals-external/practice/src/main/java/sendingsignalsexternal/orderpizza/PizzaWorkflowImpl.java
+++ b/exercises/sending-signals-external/practice/src/main/java/sendingsignalsexternal/orderpizza/PizzaWorkflowImpl.java
@@ -16,6 +16,7 @@ import sendingsignalsexternal.exceptions.OutOfServiceAreaException;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 
@@ -24,19 +25,21 @@ public class PizzaWorkflowImpl implements PizzaWorkflow {
   public static final Logger logger = Workflow.getLogger(PizzaWorkflowImpl.class);
 
   private boolean fulfilled;
+  private boolean signalProcessed;
 
   ActivityOptions options = ActivityOptions.newBuilder().setStartToCloseTimeout(Duration.ofSeconds(5)).build();
 
   private final PizzaActivities activities = Workflow.newActivityStub(PizzaActivities.class, options);
 
   @Override
-  public OrderConfirmation orderPizza(PizzaOrder order) {
+  public Optional<OrderConfirmation> orderPizza(PizzaOrder order) {
 
     String orderNumber = order.getOrderNumber();
     Customer customer = order.getCustomer();
     List<Pizza> items = order.getItems();
     boolean isDelivery = order.isDelivery();
     Address address = order.getAddress();
+    signalProcessed = false;
 
     logger.info("orderPizza Workflow Invoked");
 
@@ -62,7 +65,7 @@ public class PizzaWorkflowImpl implements PizzaWorkflow {
     logger.info("distance is {}", distance.getKilometers());
 
 
-    Workflow.await(() -> this.fulfilled);
+    Workflow.await(Duration.ofSeconds(3),() -> this.signalProcessed);
 
     OrderConfirmation confirmation;
     
@@ -73,17 +76,18 @@ public class PizzaWorkflowImpl implements PizzaWorkflow {
 
     try {
       confirmation = activities.sendBill(bill);
+      return Optional.of(confirmation);
     } catch (InvalidChargeAmountException e) {
       logger.error("Unable to bill customer");
       throw Workflow.wrap(e);
     }
 
-    return confirmation;
+    return Optional.empty();
 
   }
 
   // TODO: PART A: Implement the Signal to set `fulfilled` to the boolean value 
-  // that is passed in the Signal
+  // that is passed in the Signal, and set `signalProcessed` to true.
 
 
 }

--- a/exercises/sending-signals-external/solution/src/main/java/sendingsignalsexternal/Starter.java
+++ b/exercises/sending-signals-external/solution/src/main/java/sendingsignalsexternal/Starter.java
@@ -15,6 +15,7 @@ import sendingsignalsexternal.orderpizza.PizzaWorkflow;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class Starter {
   public static void main(String[] args) throws Exception {
@@ -46,7 +47,7 @@ public class Starter {
 
     FulfillOrderWorkflow orderWorkflow = client.newWorkflowStub(FulfillOrderWorkflow.class, fulfillWorkflowOptions);
 
-    CompletableFuture<OrderConfirmation> orderConfirmation = WorkflowClient.execute(pizzaWorkflow::orderPizza, order);
+    CompletableFuture<Optional<OrderConfirmation>> orderConfirmation = WorkflowClient.execute(pizzaWorkflow::orderPizza, order);
 
     CompletableFuture<String> fulfillOrderResult = WorkflowClient.execute(orderWorkflow::fulfillOrder, order,
         pizzaWorkflowID);

--- a/exercises/sending-signals-external/solution/src/main/java/sendingsignalsexternal/orderpizza/PizzaWorkflow.java
+++ b/exercises/sending-signals-external/solution/src/main/java/sendingsignalsexternal/orderpizza/PizzaWorkflow.java
@@ -5,12 +5,13 @@ import io.temporal.workflow.WorkflowMethod;
 import io.temporal.workflow.SignalMethod;
 import sendingsignalsexternal.model.PizzaOrder;
 import sendingsignalsexternal.model.OrderConfirmation;
+import java.util.Optional;
 
 @WorkflowInterface
 public interface PizzaWorkflow {
 
   @WorkflowMethod
-  OrderConfirmation orderPizza(PizzaOrder order);
+  Optional<OrderConfirmation> orderPizza(PizzaOrder order);
 
   @SignalMethod
   void fulfillOrderSignal(boolean bool);


### PR DESCRIPTION
Hi all, please let e know how this looks. I am happy to help out or work through this in more detail.

## What was changed
In the example for sending signals from an external client, we were doing the following differently from how I expected based on the other language courses

- when waiting for the signal, we didn't have a 3 second timeout
- the thing we were waiting on was the fulfillment, not whether or not the signal was processed. That meant that the subsequent if statement would never go into the else clause. We were forcing the order to be fulfilled, and the workflow would wait on that forever, which sort of made the boolean in the signal not needed.
- Because it waited until fulfillment, it didn't have to support returning anything other than a confirmation, so I switched that to be an Optional.

## How was this tested
I ran the code in `sending-signals-external/{practice and solution}` as I did the exercise.  I can also do the `sending-signals-client` to make sure it's running

## Remaining Questions
One thing I wasn't totally sure about was the JSON-serializability of Java's Optional. But I tried it in the fulfilled and unfulfilled states, and it seemed happy. I'm not sure if anyone has further knowledge on that