### PR TITLE
fixed imports and removed code that called non-existent methods

### DIFF
--- a/exercises/async-activity-completion/practice/src/test/java/translationworkflow/TranslationActivitiesTest.java
+++ b/exercises/async-activity-completion/practice/src/test/java/translationworkflow/TranslationActivitiesTest.java
@@ -4,14 +4,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import asyncactivitycompletion.TranslationActivities;
+import asyncactivitycompletion.TranslationActivitiesImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.temporal.failure.ActivityFailure;
 import io.temporal.testing.TestActivityEnvironment;
-import translationworkflow.model.TranslationActivityInput;
-import translationworkflow.model.TranslationActivityOutput;
+import asyncactivitycompletion.model.TranslationActivityInput;
+import asyncactivitycompletion.model.TranslationActivityOutput;
 
 public class TranslationActivitiesTest {
 

--- a/exercises/async-activity-completion/practice/src/test/java/translationworkflow/TranslationWorkflowMockTest.java
+++ b/exercises/async-activity-completion/practice/src/test/java/translationworkflow/TranslationWorkflowMockTest.java
@@ -2,16 +2,19 @@ package translationworkflow;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import asyncactivitycompletion.TranslationActivities;
+import asyncactivitycompletion.TranslationWorkflow;
+import asyncactivitycompletion.TranslationWorkflowImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.TestWorkflowExtension;
 import io.temporal.worker.Worker;
-import translationworkflow.model.TranslationActivityInput;
-import translationworkflow.model.TranslationActivityOutput;
-import translationworkflow.model.TranslationWorkflowInput;
-import translationworkflow.model.TranslationWorkflowOutput;
+import asyncactivitycompletion.model.TranslationActivityInput;
+import asyncactivitycompletion.model.TranslationActivityOutput;
+import asyncactivitycompletion.model.TranslationWorkflowInput;
+import asyncactivitycompletion.model.TranslationWorkflowOutput;
 import static org.mockito.Mockito.*;
 
 public class TranslationWorkflowMockTest {
@@ -41,6 +44,5 @@ public class TranslationWorkflowMockTest {
         workflow.sayHelloGoodbye(new TranslationWorkflowInput("Pierre", "fr"));
 
     assertEquals("Bonjour, Pierre", output.getHelloMessage());
-    assertEquals("Au revoir, Pierre", output.getGoodbyeMessage());
   }
 }

--- a/exercises/async-activity-completion/practice/src/test/java/translationworkflow/TranslationWorkflowTest.java
+++ b/exercises/async-activity-completion/practice/src/test/java/translationworkflow/TranslationWorkflowTest.java
@@ -2,16 +2,19 @@ package translationworkflow;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import asyncactivitycompletion.TranslationActivitiesImpl;
+import asyncactivitycompletion.TranslationWorkflow;
+import asyncactivitycompletion.TranslationWorkflowImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.TestWorkflowExtension;
 import io.temporal.worker.Worker;
-import translationworkflow.model.TranslationActivityInput;
-import translationworkflow.model.TranslationActivityOutput;
-import translationworkflow.model.TranslationWorkflowInput;
-import translationworkflow.model.TranslationWorkflowOutput;
+import asyncactivitycompletion.model.TranslationActivityInput;
+import asyncactivitycompletion.model.TranslationActivityOutput;
+import asyncactivitycompletion.model.TranslationWorkflowInput;
+import asyncactivitycompletion.model.TranslationWorkflowOutput;
 
 public class TranslationWorkflowTest {
 
@@ -33,6 +36,5 @@ public class TranslationWorkflowTest {
         workflow.sayHelloGoodbye(new TranslationWorkflowInput("Pierre", "fr"));
 
     assertEquals("Bonjour, Pierre", output.getHelloMessage());
-    assertEquals("Au revoir, Pierre", output.getGoodbyeMessage());
   }
 }

--- a/exercises/async-activity-completion/solution/src/test/java/translationworkflow/TranslationActivitiesTest.java
+++ b/exercises/async-activity-completion/solution/src/test/java/translationworkflow/TranslationActivitiesTest.java
@@ -4,14 +4,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import asyncactivitycompletion.TranslationActivities;
+import asyncactivitycompletion.TranslationActivitiesImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.temporal.failure.ActivityFailure;
 import io.temporal.testing.TestActivityEnvironment;
-import translationworkflow.model.TranslationActivityInput;
-import translationworkflow.model.TranslationActivityOutput;
+import asyncactivitycompletion.model.TranslationActivityInput;
+import asyncactivitycompletion.model.TranslationActivityOutput;
 
 public class TranslationActivitiesTest {
 

--- a/exercises/async-activity-completion/solution/src/test/java/translationworkflow/TranslationWorkflowMockTest.java
+++ b/exercises/async-activity-completion/solution/src/test/java/translationworkflow/TranslationWorkflowMockTest.java
@@ -2,16 +2,19 @@ package translationworkflow;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import asyncactivitycompletion.TranslationActivities;
+import asyncactivitycompletion.TranslationWorkflow;
+import asyncactivitycompletion.TranslationWorkflowImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.TestWorkflowExtension;
 import io.temporal.worker.Worker;
-import translationworkflow.model.TranslationActivityInput;
-import translationworkflow.model.TranslationActivityOutput;
-import translationworkflow.model.TranslationWorkflowInput;
-import translationworkflow.model.TranslationWorkflowOutput;
+import asyncactivitycompletion.model.TranslationActivityInput;
+import asyncactivitycompletion.model.TranslationActivityOutput;
+import asyncactivitycompletion.model.TranslationWorkflowInput;
+import asyncactivitycompletion.model.TranslationWorkflowOutput;
 import static org.mockito.Mockito.*;
 
 public class TranslationWorkflowMockTest {
@@ -41,6 +44,5 @@ public class TranslationWorkflowMockTest {
         workflow.sayHelloGoodbye(new TranslationWorkflowInput("Pierre", "fr"));
 
     assertEquals("Bonjour, Pierre", output.getHelloMessage());
-    assertEquals("Au revoir, Pierre", output.getGoodbyeMessage());
   }
 }

--- a/exercises/async-activity-completion/solution/src/test/java/translationworkflow/TranslationWorkflowTest.java
+++ b/exercises/async-activity-completion/solution/src/test/java/translationworkflow/TranslationWorkflowTest.java
@@ -2,16 +2,19 @@ package translationworkflow;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import asyncactivitycompletion.TranslationActivitiesImpl;
+import asyncactivitycompletion.TranslationWorkflow;
+import asyncactivitycompletion.TranslationWorkflowImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.TestWorkflowExtension;
 import io.temporal.worker.Worker;
-import translationworkflow.model.TranslationActivityInput;
-import translationworkflow.model.TranslationActivityOutput;
-import translationworkflow.model.TranslationWorkflowInput;
-import translationworkflow.model.TranslationWorkflowOutput;
+import asyncactivitycompletion.model.TranslationActivityInput;
+import asyncactivitycompletion.model.TranslationActivityOutput;
+import asyncactivitycompletion.model.TranslationWorkflowInput;
+import asyncactivitycompletion.model.TranslationWorkflowOutput;
 
 public class TranslationWorkflowTest {
 
@@ -33,6 +36,5 @@ public class TranslationWorkflowTest {
         workflow.sayHelloGoodbye(new TranslationWorkflowInput("Pierre", "fr"));
 
     assertEquals("Bonjour, Pierre", output.getHelloMessage());
-    assertEquals("Au revoir, Pierre", output.getGoodbyeMessage());
   }
 }


### PR DESCRIPTION
## What was changed

I changed the imports for the test classes to use the correct package names. I also removed calls related to a non-existent method for getting a goodbye message (not only did that method not exist, the exercise instructions didn't appear to mention it, so I assume the learner isn't expected to implement it).



## Why?
<!-- Tell your future self why have you made these changes -->

The tests, in their previous state, did not compile due to the incorrect package names. Even if that part was fixed, the tests would error out because they were calling a method that did not exist. My changes resolve both problems. 
